### PR TITLE
Fixes error in command line operation see #25

### DIFF
--- a/myconfig.py
+++ b/myconfig.py
@@ -157,7 +157,10 @@ class MyConfig (MyLog):
                 elif return_type == float:
                     return self.config.getfloat(self.Section, Entry)
                 elif return_type == int:
-                    return self.config.getint(self.Section, Entry)
+                    if self.config.get(self.Section, Entry) == 'None':
+                        return None
+                    else:             
+                        return self.config.getint(self.Section, Entry)
                 else:
                     self.LogErrorLine("Error in MyConfig:ReadValue: invalid type:" + str(return_type))
                     return default


### PR DESCRIPTION
Fixes error massage in command line operation as mentioned by @Secarius  and @ssanden in Issue #25
_Error in MyConfig:ReadValue: 0x279621: invalid literal for int() with base 10: 'None' : myconfig.py:160_

For the object _getint()_ None ist not an valid type. But None ist used as initial value in the config file